### PR TITLE
Add missing foreign key and index to schema.sql

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,29 +1,44 @@
 SET foreign_key_checks = 0;
 
+DROP TABLE IF EXISTS problem_user_reinforce;
+DROP TABLE IF EXISTS problems;
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    email VARCHAR(50) UNIQUE NOT NULL,
+    email VARCHAR(50) NOT NULL,
     encrypted_password VARCHAR(255) NOT NULL,
-    avatar_name VARCHAR(65)
-);
-
-DROP TABLE IF EXISTS problems;
+    avatar_name VARCHAR(65),
+    UNIQUE KEY uq_users_email (email)
+) ENGINE=InnoDB;
 
 CREATE TABLE problems (
     id INT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
-    user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE
-);
-
-DROP TABLE IF EXISTS problem_user_reinforce;
+    user_id INT NOT NULL,
+    INDEX idx_problems_user_id (user_id),
+    CONSTRAINT fk_problems_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB;
 
 CREATE TABLE problem_user_reinforce (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    user_id INT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
-    problem_id INT NOT NULL REFERENCES users(id) ON DELETE RESTRICT
-);
+    user_id INT NOT NULL,
+    problem_id INT NOT NULL,
+    INDEX idx_reinforce_user_id (user_id),
+    INDEX idx_reinforce_problem_id (problem_id),
+    UNIQUE KEY uq_user_problem (user_id, problem_id),
+    CONSTRAINT fk_reinforce_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_reinforce_problem
+        FOREIGN KEY (problem_id)
+        REFERENCES problems(id)
+        ON DELETE RESTRICT
+) ENGINE=InnoDB;
 
 SET foreign_key_checks = 1;


### PR DESCRIPTION
# Add Missing Foreign Keys and Indexes to `schema.sql`
---

## 🧾 Summary

This PR fixes incorrect foreign key definitions in `database/schema.sql` and adds the necessary indexes and constraints to properly enforce referential integrity and improve query performance.

The previous schema used inline `REFERENCES` syntax, which is not properly enforced in MySQL. This update replaces it with explicit `CONSTRAINT` definitions and ensures all tables use `InnoDB`.